### PR TITLE
[BugFix] URL was being wrongly decoded when redirecting.

### DIFF
--- a/Modules/UrlTrackerModule.cs
+++ b/Modules/UrlTrackerModule.cs
@@ -277,7 +277,7 @@ namespace InfoCaster.Umbraco.UrlTracker.Modules
                             string pathAndQuery = Uri.UnescapeDataString(redirectUri.PathAndQuery);
                             redirectUri = new Uri(string.Format("{0}://{1}{2}/{3}{4}", redirectUri.Scheme, redirectUri.Host, redirectUri.Port != 80 ? string.Concat(":", redirectUri.Port) : string.Empty, pathAndQuery.Contains('?') ? pathAndQuery.Substring(0, pathAndQuery.IndexOf('?')) : pathAndQuery.StartsWith("/") ? pathAndQuery.Substring(1) : pathAndQuery, newQueryString.HasKeys() ? string.Concat("?", newQueryString.ToQueryString()) : string.Empty));
                         }
-                        response.RedirectLocation = redirectUri.ToString();
+                        response.RedirectLocation = redirectUri.AbsoluteUri;
                         LoggingHelper.LogInformation("UrlTracker HttpModule | Response redirectlocation set to: {0}", response.RedirectLocation);
                     }
                     response.End();


### PR DESCRIPTION
URL was being wrongly URL-decoded when redirecting (e.g. '%2F' in query
string was being decoded to '/'.  The solution is to use Uri.AbsoluteUri
instead of Uri.ToString() - see
http://connect.microsoft.com/VisualStudio/feedback/details/475650/system-uri-constructor-automatically-urldecodes-26-and-3d-to-and
