### PR TITLE
Add an index to the database.

### DIFF
--- a/SQL/update-table-3.sql
+++ b/SQL/update-table-3.sql
@@ -1,0 +1,20 @@
+IF EXISTS (SELECT 1 FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME = 'icUrlTracker')
+BEGIN
+    CREATE NONCLUSTERED INDEX [IX_icUrlTracker] ON [icUrlTracker] 
+    (
+        [ForceRedirect] ASC,
+        [Is404] ASC,
+        [RedirectRootNodeId] ASC
+    )
+    INCLUDE ( [Id],
+    [OldUrl],
+    [OldUrlQueryString],
+    [OldRegex],
+    [RedirectNodeId],
+    [RedirectUrl],
+    [RedirectHttpCode],
+    [RedirectPassThroughQueryString],
+    [Notes],
+    [Referrer],
+    [Inserted]) WITH (PAD_INDEX  = OFF, STATISTICS_NORECOMPUTE  = OFF, SORT_IN_TEMPDB = OFF, IGNORE_DUP_KEY = OFF, DROP_EXISTING = OFF, ONLINE = OFF, ALLOW_ROW_LOCKS  = ON, ALLOW_PAGE_LOCKS  = ON) ON [PRIMARY]
+END


### PR DESCRIPTION
The database is seriously in need of an index to preserve website performance, especially once there are thousands of 404 entries. This pull request contains the index recommended by Database Engine Tuning Advisor for the query that is made for every page request. When we applied this, our SQL server CPU load dropped from 80% to 5%, and web page response times dropped from 500ms to 20ms! It may be possible to define a better index that is also optimised for storage space as well as performance, but I have not done that yet.
