### PR TITLE
Added new setting for appending the port number

### DIFF
--- a/Models/UrlTrackerModel.cs
+++ b/Models/UrlTrackerModel.cs
@@ -69,10 +69,10 @@ namespace InfoCaster.Umbraco.UrlTracker.Models
                 List<UrlTrackerDomain> domains = UmbracoHelper.GetDomains();
                 domain = domains.FirstOrDefault(x => x.NodeId == RedirectRootNode.Id);
                 if (domain == null)
-                    domain = new UrlTrackerDomain(-1, RedirectRootNode.Id, string.Concat(HttpContext.Current.Request.Url.Host, HttpContext.Current.Request.Url.IsDefaultPort ? string.Empty : string.Concat(":", HttpContext.Current.Request.Url.Port)));
+                    domain = new UrlTrackerDomain(-1, RedirectRootNode.Id, string.Concat(HttpContext.Current.Request.Url.Host, HttpContext.Current.Request.Url.IsDefaultPort && !UrlTrackerSettings.AppendPortNumber ? string.Empty : string.Concat(":", HttpContext.Current.Request.Url.Port)));
 
                 Uri domainUri = new Uri(domain.UrlWithDomain);
-                string domainOnly = string.Format("{0}://{1}{2}", domainUri.Scheme, domainUri.Host, domainUri.IsDefaultPort ? string.Empty : string.Concat(":", domainUri.Port));
+                string domainOnly = string.Format("{0}://{1}{2}", domainUri.Scheme, domainUri.Host, domainUri.IsDefaultPort && !UrlTrackerSettings.AppendPortNumber ? string.Empty : string.Concat(":", domainUri.Port));
 
                 return string.Format("{0}{1}{2}", new Uri(string.Concat(domainOnly, !domainOnly.EndsWith("/") && !OldUrl.StartsWith("/") ? "/" : string.Empty, UrlTrackerHelper.ResolveUmbracoUrl(OldUrl))), !string.IsNullOrEmpty(OldUrlQueryString) ? "?" : string.Empty, OldUrlQueryString);
             }
@@ -85,7 +85,7 @@ namespace InfoCaster.Umbraco.UrlTracker.Models
                     RedirectUrl :
                     !RedirectRootNode.NiceUrl.EndsWith("#") && RedirectNodeId.HasValue ?
                         new Uri(umbraco.library.NiceUrl(RedirectNodeId.Value).StartsWith("http") ? umbraco.library.NiceUrl(RedirectNodeId.Value) :
-                            string.Format("{0}://{1}{2}{3}", HttpContext.Current.Request.Url.Scheme, HttpContext.Current.Request.Url.Host, HttpContext.Current.Request.Url.Port != 80 ?
+                            string.Format("{0}://{1}{2}{3}", HttpContext.Current.Request.Url.Scheme, HttpContext.Current.Request.Url.Host, HttpContext.Current.Request.Url.Port != 80 && UrlTrackerSettings.AppendPortNumber ?
                                 string.Concat(":", HttpContext.Current.Request.Url.Port) :
                                 string.Empty, umbraco.library.NiceUrl(RedirectNodeId.Value)
                             )

--- a/Modules/UrlTrackerModule.cs
+++ b/Modules/UrlTrackerModule.cs
@@ -229,7 +229,7 @@ namespace InfoCaster.Umbraco.UrlTracker.Modules
                     {
                         if (redirectUrl == "/")
                             redirectUrl = string.Empty;
-                        Uri redirectUri = new Uri(redirectUrl.StartsWith("http") ? redirectUrl : string.Format("{0}://{1}{2}/{3}", request.Url.Scheme, request.Url.Host, request.Url.Port != 80 ? string.Concat(":", request.Url.Port) : string.Empty, redirectUrl));
+                        Uri redirectUri = new Uri(redirectUrl.StartsWith("http") ? redirectUrl : string.Format("{0}://{1}{2}/{3}", request.Url.Scheme, request.Url.Host, request.Url.Port != 80 && UrlTrackerSettings.AppendPortNumber ? string.Concat(":", request.Url.Port) : string.Empty, redirectUrl));
                         if (redirectPassThroughQueryString)
                         {
                             NameValueCollection redirectQueryString = HttpUtility.ParseQueryString(redirectUri.Query);
@@ -237,10 +237,10 @@ namespace InfoCaster.Umbraco.UrlTracker.Modules
                             if (redirectQueryString.HasKeys())
                                 newQueryString = newQueryString.Merge(redirectQueryString);
                             string pathAndQuery = Uri.UnescapeDataString(redirectUri.PathAndQuery);
-                            redirectUri = new Uri(string.Format("{0}://{1}{2}/{3}{4}", redirectUri.Scheme, redirectUri.Host, redirectUri.Port != 80 ? string.Concat(":", redirectUri.Port) : string.Empty, pathAndQuery.Contains('?') ? pathAndQuery.Substring(0, pathAndQuery.IndexOf('?')) : pathAndQuery.StartsWith("/") ? pathAndQuery.Substring(1) : pathAndQuery, newQueryString.HasKeys() ? string.Concat("?", newQueryString.ToQueryString()) : string.Empty));
+                            redirectUri = new Uri(string.Format("{0}://{1}{2}/{3}{4}", redirectUri.Scheme, redirectUri.Host, redirectUri.Port != 80 && UrlTrackerSettings.AppendPortNumber ? string.Concat(":", redirectUri.Port) : string.Empty, pathAndQuery.Contains('?') ? pathAndQuery.Substring(0, pathAndQuery.IndexOf('?')) : pathAndQuery.StartsWith("/") ? pathAndQuery.Substring(1) : pathAndQuery, newQueryString.HasKeys() ? string.Concat("?", newQueryString.ToQueryString()) : string.Empty));
                         }
 
-                        if (redirectUri == new Uri(string.Format("{0}://{1}{2}/{3}", request.Url.Scheme, request.Url.Host, request.Url.Port != 80 ? string.Concat(":", request.Url.Port) : string.Empty, request.RawUrl.StartsWith("/") ? request.RawUrl.Substring(1) : request.RawUrl)))
+                        if (redirectUri == new Uri(string.Format("{0}://{1}{2}/{3}", request.Url.Scheme, request.Url.Host, request.Url.Port != 80 && UrlTrackerSettings.AppendPortNumber ? string.Concat(":", request.Url.Port) : string.Empty, request.RawUrl.StartsWith("/") ? request.RawUrl.Substring(1) : request.RawUrl)))
                         {
                             LoggingHelper.LogInformation("UrlTracker HttpModule | Redirect URL is the same as Request.RawUrl; don't redirect");
                             return;
@@ -321,7 +321,7 @@ namespace InfoCaster.Umbraco.UrlTracker.Modules
                         if (n != null && n.Name != null && n.Id > 0)
                         {
                             string tempUrl = UmbracoHelper.GetUrl(redirectNodeId);
-                            redirectUrl = tempUrl.StartsWith("http") ? tempUrl : string.Format("{0}://{1}{2}{3}", HttpContext.Current.Request.Url.Scheme, HttpContext.Current.Request.Url.Host, HttpContext.Current.Request.Url.Port != 80 ? string.Concat(":", HttpContext.Current.Request.Url.Port) : string.Empty, tempUrl);
+                            redirectUrl = tempUrl.StartsWith("http") ? tempUrl : string.Format("{0}://{1}{2}{3}", HttpContext.Current.Request.Url.Scheme, HttpContext.Current.Request.Url.Host, HttpContext.Current.Request.Url.Port != 80 && UrlTrackerSettings.AppendPortNumber ? string.Concat(":", HttpContext.Current.Request.Url.Port) : string.Empty, tempUrl);
                             if (redirectUrl.StartsWith("http"))
                             {
                                 Uri redirectUri = new Uri(redirectUrl);
@@ -384,7 +384,7 @@ namespace InfoCaster.Umbraco.UrlTracker.Modules
                     if (n != null && n.Name != null && n.Id > 0)
                     {
                         string tempUrl = UmbracoHelper.GetUrl(forcedRedirect.RedirectNodeId.Value);
-                        redirectUrl = tempUrl.StartsWith("http") ? tempUrl : string.Format("{0}://{1}{2}{3}", HttpContext.Current.Request.Url.Scheme, HttpContext.Current.Request.Url.Host, HttpContext.Current.Request.Url.Port != 80 ? string.Concat(":", HttpContext.Current.Request.Url.Port) : string.Empty, tempUrl);
+                        redirectUrl = tempUrl.StartsWith("http") ? tempUrl : string.Format("{0}://{1}{2}{3}", HttpContext.Current.Request.Url.Scheme, HttpContext.Current.Request.Url.Host, HttpContext.Current.Request.Url.Port != 80 && UrlTrackerSettings.AppendPortNumber ? string.Concat(":", HttpContext.Current.Request.Url.Port) : string.Empty, tempUrl);
                         if (redirectUrl.StartsWith("http"))
                         {
                             Uri redirectUri = new Uri(redirectUrl);

--- a/UrlTrackerSettings.cs
+++ b/UrlTrackerSettings.cs
@@ -147,10 +147,44 @@ namespace InfoCaster.Umbraco.UrlTracker
             }
         }
 
+        /// <summary>
+        /// Gets a value indicating whether or not to append port numbers to URLs. Default is true.
+        /// </summary>
+        /// <value>
+        ///   <c>true</c> if we are to append the port number; otherwise, <c>false</c>.
+        /// </value>
+        public static bool AppendPortNumber
+        {
+            get
+            {
+                if (!_appendPortNumber.HasValue)
+                {
+                    bool appendPortNumber = true;
+
+                    if (!string.IsNullOrEmpty(ConfigurationManager.AppSettings["urlTracker:appendPortNumber"]))
+                    {
+                        bool parsedAppSetting;
+
+                        if (bool.TryParse(
+                            ConfigurationManager.AppSettings["urlTracker:appendPortNumber"],
+                            out parsedAppSetting))
+                        {
+                            appendPortNumber = parsedAppSetting;
+                        }
+                    }
+
+                    _appendPortNumber = appendPortNumber;
+                }
+
+                return _appendPortNumber.Value;
+            }
+        }
+
         static bool? _isDisabled;
         static bool? _enableLogging;
         static string[] _notFoundUrlsToIgnore;
         static bool? _isTrackingDisabled;
         static bool? _isNotFoundTrackingDisabled;
+        static bool? _appendPortNumber;
     }
 }


### PR DESCRIPTION
Useful for when the site is running on a non-standard port number.

Our scenario:

We have a server located behind a load balancer. Our sites are running on port 8080.

 The load balancer forwards requests for port 80 to the web server on port 8080.

Because port 8080 is an internal port only, redirects that append the port number don't work.

This setting allows us to turn port appending on or off.
