### PR TITLE
Force URLs to lowercase when searching

### DIFF
--- a/Modules/UrlTrackerModule.cs
+++ b/Modules/UrlTrackerModule.cs
@@ -443,7 +443,7 @@ namespace InfoCaster.Umbraco.UrlTracker.Modules
             if (forcedRedirects == null || !forcedRedirects.Any())
                 return;
 
-            foreach (UrlTrackerModel forcedRedirect in forcedRedirects.Where(x => !x.Is404 && x.RedirectRootNodeId == rootNodeId && (x.OldUrl == urlWithoutQueryString || x.OldUrl == shortestUrl)).OrderBy(x => x.RedirectHttpCode == 410 ? 2 : 1).ThenByDescending(x => x.OldUrlQueryString))
+            foreach (UrlTrackerModel forcedRedirect in forcedRedirects.Where(x => !x.Is404 && x.RedirectRootNodeId == rootNodeId && (x.OldUrl.ToLower() == urlWithoutQueryString.ToLower() || x.OldUrl.ToLower() == shortestUrl.ToLower())).OrderBy(x => x.RedirectHttpCode == 410 ? 2 : 1).ThenByDescending(x => x.OldUrlQueryString))
             {
                 LoggingHelper.LogInformation("UrlTracker HttpModule | URL match found");
                 if (forcedRedirect.RedirectNodeId.HasValue && forcedRedirect.RedirectHttpCode != (int)HttpStatusCode.Gone)

--- a/Repositories/UrlTrackerRepository.cs
+++ b/Repositories/UrlTrackerRepository.cs
@@ -197,12 +197,12 @@ namespace InfoCaster.Umbraco.UrlTracker.Repositories
         [Obsolete("Remove not found entries also with root id, use other method")]
         public static UrlTrackerModel GetNotFoundEntryByUrl(string url)
         {
-            return GetNotFoundEntries().Single(x => x.OldUrl == url);
+            return GetNotFoundEntries().Single(x => x.OldUrl.ToLower() == url.ToLower());
         }
 
         public static UrlTrackerModel GetNotFoundEntryByRootAndUrl(int redirectRootNodeId, string url)
         {
-            return GetNotFoundEntries().Single(x => x.OldUrl == url && x.RedirectRootNodeId == redirectRootNodeId);
+            return GetNotFoundEntries().Single(x => x.OldUrl.ToLower() == url.ToLower() && x.RedirectRootNodeId == redirectRootNodeId);
         }
 
         public static List<UrlTrackerModel> GetUrlTrackerEntries(int? maximumRows, int? startRowIndex, string sortExpression = "", bool _404 = false, bool include410Gone = false, bool showAutoEntries = true, bool showCustomEntries = true, bool showRegexEntries = true, string keyword = "", bool onlyForcedRedirects = false)


### PR DESCRIPTION
When searching in cache I noticed that it was case sensitive. Given the environment we are in (.NET, Windows etc.) this isn't right. URL matching should be case insensitive.

It is fine when searching in DB.