### PR TITLE
[BugFix] AdvancedView is throwing an exception when having a single domain configured in umbraco.

### DIFF
--- a/UI/UserControls/AdvancedView.ascx.cs
+++ b/UI/UserControls/AdvancedView.ascx.cs
@@ -43,8 +43,12 @@ namespace InfoCaster.Umbraco.UrlTracker.UI.UserControls
                 pnlRootNode.Visible = false;
             }
 
-            ddlRootNode.SelectedValue = UrlTrackerModel.RedirectRootNodeId.ToString();
-            if (!string.IsNullOrEmpty(UrlTrackerModel.OldRegex) && string.IsNullOrEmpty(UrlTrackerModel.OldUrl))
+	        if (ddlRootNode.Items.Count > 1)
+	        {
+		        ddlRootNode.SelectedValue = UrlTrackerModel.RedirectRootNodeId.ToString();
+	        }
+
+	        if (!string.IsNullOrEmpty(UrlTrackerModel.OldRegex) && string.IsNullOrEmpty(UrlTrackerModel.OldUrl))
             {
                 tbOldRegex.Text = UrlTrackerModel.OldRegex;
             }


### PR DESCRIPTION
UrlTracking is throwing an exception in AdvancedView, when trying to set ddlRootNode.SelectedValue to UrlTrackerModel.RedirectRootNodeId. The problem occurs only when umbraco is configured with a single domain.

