### PR TITLE
Fixes issue #90

### DIFF
--- a/Modules/UrlTrackerModule.cs
+++ b/Modules/UrlTrackerModule.cs
@@ -37,7 +37,7 @@ namespace InfoCaster.Umbraco.UrlTracker.Modules
         public void Init(HttpApplication context)
         {
             context.AcquireRequestState += context_AcquireRequestState;
-            context.EndRequest += context_EndRequest;
+            context.PostRequestHandlerExecute += context_PostRequestHandlerExecute;
 
             LoggingHelper.LogInformation("UrlTracker HttpModule | Subscribed to AcquireRequestState and EndRequest events");
         }
@@ -75,7 +75,7 @@ namespace InfoCaster.Umbraco.UrlTracker.Modules
                 UrlTrackerDo("AcquireRequestState", ignoreHttpStatusCode: true);
         }
 
-        void context_EndRequest(object sender, EventArgs e)
+        void context_PostRequestHandlerExecute(object sender, EventArgs e)
         {
             if (_execute)
                 UrlTrackerDo("EndRequest");


### PR DESCRIPTION
NullReferenceException with 7.3 Beta 3 and Multiple root nodes

Basically wha you had before *should* never have worked, you hooked into Umbraco at the very end of the request where `UmbracoContext.Current.Application` had been set to null. It looks like we null that out a bit earlier now in 7.3.0 we nullify .Application there in order to make sure it's not disposed.

This fixes the problem and is basically the same thing that was fixed for Dialogue a while ago.

Sorry for the delay!