### PR TITLE
Regular Expression Validation Fix

### DIFF
--- a/UI/res/js/main.js
+++ b/UI/res/js/main.js
@@ -5,7 +5,7 @@ function pageLoad() {
     $(".wrap input[type='hidden']").addClass("redirect-to").addClass("redirect-to-node");
 
     $.validator.addMethod("queryString", function (value) {
-        return value == "" || /^(?:[^?&=]+=?[^&=]+&?)+$/.test(value);
+        return value == "" || /^([\w-]+(=[\w-]*)?(&[\w-]+(=[\w-]*)?)*)?$/.test(value);
     }, "Please enter a valid query string");
 
     // Initialize validation on the entire ASP.NET form.

--- a/UI/res/js/main.js
+++ b/UI/res/js/main.js
@@ -5,7 +5,7 @@ function pageLoad() {
     $(".wrap input[type='hidden']").addClass("redirect-to").addClass("redirect-to-node");
 
     $.validator.addMethod("queryString", function (value) {
-        return value == "" || /^([\w-]+(=[\w-]*)?(&[\w-]+(=[\w-]*)?)*)?$/.test(value);
+        return value == "" || /^([A-Za-z0-9\%\+\_\-\.\*]+(=[A-Za-z0-9\%\+\_\-\.\*]*)?(&[A-Za-z0-9\%\+\_\-\.\*]+(=[A-Za-z0-9\%\+\_\-\.\*]*)?)*)?$/.test(value);
     }, "Please enter a valid query string");
 
     // Initialize validation on the entire ASP.NET form.


### PR DESCRIPTION
1) Certain regular expressions caused catastrophic regular expression backtracking, crashing the user's browser when they tabbed off the query string field.

2) Previous regular expression did not accept all valid characters for a query string.