### PR TITLE
UrlTracker issue #104

### DIFF
--- a/Models/UrlTrackerDomain.cs
+++ b/Models/UrlTrackerDomain.cs
@@ -13,7 +13,17 @@ namespace InfoCaster.Umbraco.UrlTracker.Models
         public int NodeId { get; set; }
         public string Name { get; set; }
 
-        public Node Node { get { return new Node(NodeId); } }
+        private Node _node = null;
+        public Node Node
+        {
+            get
+            {
+                if (_node == null)
+                    _node = new Node(NodeId);
+                return _node;
+            }
+        }
+
         public string UrlWithDomain
         {
             get

--- a/Modules/UrlTrackerModule.cs
+++ b/Modules/UrlTrackerModule.cs
@@ -139,7 +139,7 @@ namespace InfoCaster.Umbraco.UrlTracker.Modules
                     string fullRawUrl;
                     string previousFullRawUrlTest;
                     string fullRawUrlTest;
-                    fullRawUrl = previousFullRawUrlTest = fullRawUrlTest = string.Format("{0}{1}{2}{3}", request.Url.Scheme, Uri.SchemeDelimiter, request.Url.Host, request.RawUrl);
+                    fullRawUrl = previousFullRawUrlTest = fullRawUrlTest = string.Format("{0}{1}{2}{3}", request.Url.Scheme, Uri.SchemeDelimiter, request.Url.Host, request.Url.AbsolutePath);
 
                     UrlTrackerDomain urlTrackerDomain;
                     do


### PR DESCRIPTION
Fixed issue which I reported. When domain is specified on umbraco website, querystring is being mistakenly being passed into LoadUrlTrackerMatchesFrom methods causing no matches to be found. 
