### PR TITLE
[Bugfix] Edit pages can save values from previously viewed redirect

### DIFF
--- a/UI/UserControls/AdvancedView.ascx.cs
+++ b/UI/UserControls/AdvancedView.ascx.cs
@@ -48,22 +48,17 @@ namespace InfoCaster.Umbraco.UrlTracker.UI.UserControls
                 ddlRootNode.SelectedValue = UrlTrackerModel.RedirectRootNodeId.ToString();
             }
 
-            if (!string.IsNullOrEmpty(UrlTrackerModel.OldRegex) && string.IsNullOrEmpty(UrlTrackerModel.OldUrl))
-            {
-                tbOldRegex.Text = UrlTrackerModel.OldRegex;
-            }
-            else
-            {
-                tbOldUrl.Text = UrlTrackerModel.OldUrl;
-                tbOldUrlQueryString.Text = UrlTrackerModel.OldUrlQueryString;
-            }
+            tbOldRegex.Text = UrlTrackerModel.OldRegex;
+            tbOldUrl.Text = UrlTrackerModel.OldUrl;
+            tbOldUrlQueryString.Text = UrlTrackerModel.OldUrlQueryString;
+            
             if (UrlTrackerModel.RedirectNodeId.HasValue)
                 cpRedirectNode.Value = UrlTrackerModel.RedirectNodeId.Value.ToString();
             tbRedirectUrl.Text = UrlTrackerModel.RedirectUrl;
-            if (UrlTrackerModel.RedirectHttpCode == 301)
-                rbPermanent.Checked = true;
-            else if (UrlTrackerModel.RedirectHttpCode == 302)
-                rbTemporary.Checked = true;
+            
+            rbPermanent.Checked = UrlTrackerModel.RedirectHttpCode == 301;
+            rbTemporary.Checked = UrlTrackerModel.RedirectHttpCode == 302;
+
             cbRedirectPassthroughQueryString.Checked = UrlTrackerModel.RedirectPassThroughQueryString;
             cbForceRedirect.Checked = UrlTrackerModel.ForceRedirect;
             tbNotes.Text = UrlTrackerModel.Notes;

--- a/UI/UserControls/CustomView.ascx.cs
+++ b/UI/UserControls/CustomView.ascx.cs
@@ -55,6 +55,8 @@ namespace InfoCaster.Umbraco.UrlTracker.UI.UserControls
             if (!string.IsNullOrEmpty(UrlTrackerModel.OldRegex) && string.IsNullOrEmpty(UrlTrackerModel.OldUrl))
             {
                 mvRedirectFrom.SetActiveView(vwRedirectFromRegex);
+                tbOldUrl.Text = null;
+                tbOldUrlQueryString.Text = null;
                 tbOldRegex.Text = UrlTrackerModel.OldRegex;
             }
             else
@@ -62,15 +64,16 @@ namespace InfoCaster.Umbraco.UrlTracker.UI.UserControls
                 mvRedirectFrom.SetActiveView(vwRedirectFromUrl);
                 tbOldUrl.Text = UrlTrackerModel.OldUrl;
                 tbOldUrlQueryString.Text = UrlTrackerModel.OldUrlQueryString;
+                tbOldRegex.Text = null;
             }
             mvRedirect.SetActiveView(UrlTrackerModel.RedirectNodeId.HasValue ? vwRedirectNode : vwRedirectUrl);
             if (UrlTrackerModel.RedirectNodeId.HasValue)
                 cpRedirectNode.Value = UrlTrackerModel.RedirectNodeId.Value.ToString();
             tbRedirectUrl.Text = UrlTrackerModel.RedirectUrl;
-            if (UrlTrackerModel.RedirectHttpCode == 301)
-                rbPermanent.Checked = true;
-            else if (UrlTrackerModel.RedirectHttpCode == 302)
-                rbTemporary.Checked = true;
+
+            rbPermanent.Checked = UrlTrackerModel.RedirectHttpCode == 301;
+            rbTemporary.Checked = UrlTrackerModel.RedirectHttpCode == 302;
+
             cbRedirectPassthroughQueryString.Checked = UrlTrackerModel.RedirectPassThroughQueryString;
             cbForceRedirect.Checked = UrlTrackerModel.ForceRedirect;
             tbNotes.Text = UrlTrackerModel.Notes;


### PR DESCRIPTION
The addresses issue #126

I updated the CustomView and AdvancedView to make sure they set all fields, including those not visible, to the appropriate values of the current redirect. Previously some of the fields in the form were not getting their values set based on the type of redirect currently being viewed. Because the view is shared, values from a previously viewed redirect could carry over and then be saved without the user knowing.