### PR TITLE
[Bugfix] Forced redirect cache not updated in multi-server environment

### DIFF
--- a/UI/UrlTrackerInfo.aspx
+++ b/UI/UrlTrackerInfo.aspx
@@ -74,6 +74,14 @@
                 <h4>urlTracker:hasDomainOnChildNode</h4>
                 <h5>boolean (false)</h5>
                 <p>Set to true if a childnode has a domain</p>
+                <h4>urlTracker:forcedRedirectCacheTimeoutEnabled</h4>
+                <h5>boolean (false)</h5>
+                <p>Set to true to cache forced redirects for a period of time.</p>
+                <p>Setting this to true will enabled forced redirect updates and additions to propagate to all servers in a multi-server environment</p>
+                <h4>urlTracker:forcedRedirectCacheTimeoutSeconds</h4>
+                <h5>int (14400)</h5>
+                <p>Amount of time, in seconds, that the forced redirects will be cached for. Default is 14400 seconds (4 hours). The default value will be used when the app setting is less than 1.</p>
+                <p>This setting does nothing unless urlTracker:forcedRedirectCacheTimeoutEnabled is true</p>
             </div>
             <div class="tab-pane" id="qa">
                 <p>Some questions and answers. This section will be expanded when people start asking more questions on the forum ;-)</p>

--- a/UrlTrackerSettings.cs
+++ b/UrlTrackerSettings.cs
@@ -217,6 +217,65 @@ namespace InfoCaster.Umbraco.UrlTracker
             }
         }
 
+        /// <summary>
+        /// Gets a value indicating whether or not forced redirects should be cached for a period of time. Default is false.
+        /// Setting this to true will enabled forced redirect updates and additions to propagate to all servers in a multi-server environment
+        /// </summary>
+        /// <value>
+        ///   <c>true</c> if we are to cache forced redirects for a period of time; otherwise, <c>false</c>.
+        /// </value>
+        /// <remarks>
+        /// appSetting: 'urlTracker:forcedRedirectCacheTimeoutEnabled'
+        /// </remarks>
+        public static bool ForcedRedirectCacheTimeoutEnabled
+        {
+            get
+            {
+                if (!_forcedRedirectCacheTimeoutEnabled.HasValue)
+                {
+                    bool forcedRedirectCacheTimeoutEnabled = false;
+                    if (!string.IsNullOrEmpty(ConfigurationManager.AppSettings["urlTracker:forcedRedirectCacheTimeoutEnabled"]))
+                    {
+                        bool parsedAppSetting;
+                        if (bool.TryParse(ConfigurationManager.AppSettings["urlTracker:forcedRedirectCacheTimeoutEnabled"], out parsedAppSetting))
+                            forcedRedirectCacheTimeoutEnabled = parsedAppSetting;
+                    }
+                    _forcedRedirectCacheTimeoutEnabled = forcedRedirectCacheTimeoutEnabled;
+                }
+                return _forcedRedirectCacheTimeoutEnabled.Value;
+            }
+        }
+
+        /// <summary>
+        /// Amount of time, in seconds, that the forced redirects will be cached for. Default is 14400 (4 hours).
+        /// The default value will be used when the app setting is less than 1.
+        /// This setting does nothing unless urlTracker:forcedRedirectCacheTimeoutEnabled is true
+        /// </summary>
+        /// <remarks>
+        /// appSetting: 'urlTracker:forcedRedirectCacheTimeoutSeconds'
+        /// </remarks>
+        public static int ForcedRedirectCacheTimeoutSeconds
+        {
+            get
+            {
+                if (!_forcedRedirectCacheTimeoutSeconds.HasValue)
+                {
+                    int forcedRedirectCacheTimeoutSeconds = 14400; // 4 hours
+                    if (!string.IsNullOrEmpty(ConfigurationManager.AppSettings["urlTracker:forcedRedirectCacheTimeoutSeconds"]))
+                    {
+                        int parsedAppSetting;
+                        if (int.TryParse(ConfigurationManager.AppSettings["urlTracker:forcedRedirectCacheTimeoutSeconds"], out parsedAppSetting)
+                            && parsedAppSetting > 0)
+                        {
+                            forcedRedirectCacheTimeoutSeconds = parsedAppSetting;
+                        }
+                    }
+                    _forcedRedirectCacheTimeoutSeconds = forcedRedirectCacheTimeoutSeconds;
+                }
+                return _forcedRedirectCacheTimeoutSeconds.Value;
+            }
+        }
+        
 
         static bool? _isDisabled;
         static bool? _enableLogging;
@@ -225,5 +284,7 @@ namespace InfoCaster.Umbraco.UrlTracker
         static bool? _isNotFoundTrackingDisabled;
         static bool? _appendPortNumber;
         static bool? _hasDomainOnChildNode;
+        static bool? _forcedRedirectCacheTimeoutEnabled;
+        static int? _forcedRedirectCacheTimeoutSeconds;
     }
 }


### PR DESCRIPTION
This is my proposed solution to issue #129

Here I am creating 2 new optional settings: 
- urlTracker:forcedRedirectCacheTimeoutEnabled
- urlTracker:forcedRedirectCacheTimeoutSeconds

The idea is that when you use UrlTracker in a multi-server environment, you can turn on 'urlTracker:forcedRedirectCacheTimeoutEnabled' to have the forced redirect cache rebuilt on a schedule. With a master slave setup, this will allow forced redirect changes on the master to eventually make it to the slave machine(s) based on a configurable time interval (urlTracker:forcedRedirectCacheTimeoutSeconds).

Single server environments and ones that don't care about forced redirects will have the exact same behavior they have now. This new feature must be explicitly enabled in the config.