### PR TITLE
New helpful AbsoluteRedirectLocation setting

### DIFF
--- a/Modules/UrlTrackerModule.cs
+++ b/Modules/UrlTrackerModule.cs
@@ -334,7 +334,7 @@ namespace InfoCaster.Umbraco.UrlTracker.Modules
                             LoggingHelper.LogInformation("UrlTracker HttpModule | Redirect URL is the same as Request.RawUrl; don't redirect");
                             return;
                         }
-                        if (request.Url.Host.Equals(redirectUri.Host, StringComparison.OrdinalIgnoreCase))
+                        if (!UrlTrackerSettings.AbsoluteRedirectLocation && request.Url.Host.Equals(redirectUri.Host, StringComparison.OrdinalIgnoreCase))
                         {
                             redirectLocation = redirectUri.PathAndQuery + redirectUri.Fragment;
                         }

--- a/UI/UrlTrackerInfo.aspx
+++ b/UI/UrlTrackerInfo.aspx
@@ -82,6 +82,9 @@
                 <h5>int (14400)</h5>
                 <p>Amount of time, in seconds, that the forced redirects will be cached for. Default is 14400 seconds (4 hours). The default value will be used when the app setting is less than 1.</p>
                 <p>This setting does nothing unless urlTracker:forcedRedirectCacheTimeoutEnabled is true</p>
+                <h4>urlTracker:absoluteRedirectLocation</h4>
+                <h5>boolean (false)</h5>
+                <p>Set to true to use absolute redirect URLs</p>
             </div>
             <div class="tab-pane" id="qa">
                 <p>Some questions and answers. This section will be expanded when people start asking more questions on the forum ;-)</p>

--- a/UrlTrackerSettings.cs
+++ b/UrlTrackerSettings.cs
@@ -275,6 +275,31 @@ namespace InfoCaster.Umbraco.UrlTracker
                 return _forcedRedirectCacheTimeoutSeconds.Value;
             }
         }
+
+        /// <summary>
+        /// Gets a value indicating whether or not to use absolute redirect URLs. Default is false.
+        /// </summary>
+        /// <value>
+        ///   <c>true</c> if we are to use absolute URLs; otherwise, <c>false</c>.
+        /// </value>
+        public static bool AbsoluteRedirectLocation
+        {
+            get
+            {
+                if (!_absoluteRedirectLocation.HasValue)
+                {
+                    bool absoluteRedirectLocation = false;
+                    if (!string.IsNullOrEmpty(ConfigurationManager.AppSettings["urlTracker:absoluteRedirectLocation"]))
+                    {
+                        bool parsedAppSetting;
+                        if (bool.TryParse(ConfigurationManager.AppSettings["urlTracker:absoluteRedirectLocation"], out parsedAppSetting))
+                            absoluteRedirectLocation = parsedAppSetting;
+                    }
+                    _absoluteRedirectLocation = absoluteRedirectLocation;
+                }
+                return _absoluteRedirectLocation.Value;
+            }
+        }
         
 
         static bool? _isDisabled;
@@ -286,5 +311,6 @@ namespace InfoCaster.Umbraco.UrlTracker
         static bool? _hasDomainOnChildNode;
         static bool? _forcedRedirectCacheTimeoutEnabled;
         static int? _forcedRedirectCacheTimeoutSeconds;
+        static bool? _absoluteRedirectLocation;
     }
 }


### PR DESCRIPTION
My Umbraco instance is served via reverse proxy and I found that absolute url in Location header are required in my environment.